### PR TITLE
Trying to symlink ament_index structure; but no bazel runfiles?

### DIFF
--- a/bazel_ros2_rules/WORKSPACE
+++ b/bazel_ros2_rules/WORKSPACE
@@ -2,13 +2,16 @@ workspace(name = "bazel_ros2_rules")
 
 # Skylib workspace boilerplate
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "bazel_skylib",
+    sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
         "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
     ],
-    sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
 )
+
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
 bazel_skylib_workspace()

--- a/bazel_ros2_rules/WORKSPACE
+++ b/bazel_ros2_rules/WORKSPACE
@@ -1,1 +1,14 @@
 workspace(name = "bazel_ros2_rules")
+
+# Skylib workspace boilerplate
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+    ],
+    sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+)
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()

--- a/bazel_ros2_rules/ros2/defs.bzl
+++ b/bazel_ros2_rules/ros2/defs.bzl
@@ -50,6 +50,7 @@ COMMON_FILES_MANIFEST = [
     "resources/templates/prologue.bazel",
     "resources/templates/run.bash.in",
 
+    "tools/ament_index.bzl",
     "tools/common.bzl",
     "tools/dload.bzl",
     "tools/dload_cc.bzl",

--- a/bazel_ros2_rules/ros2/defs.bzl
+++ b/bazel_ros2_rules/ros2/defs.bzl
@@ -1,7 +1,6 @@
 # -*- python -*-
 
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "patch", "update_attrs")
-
 load("//tools:execute.bzl", "execute_or_fail")
 
 COMMON_FILES_MANIFEST = [
@@ -9,11 +8,9 @@ COMMON_FILES_MANIFEST = [
     "ros_py.bzl",
     "rosidl.bzl",
     "_calculate_rosidl_capitalization.bzl",
-
     "resources/cmake_tools/__init__.py",
     "resources/cmake_tools/packages.py",
     "resources/cmake_tools/server_mode.py",
-
     "resources/rmw_isolation/__init__.py",
     "resources/rmw_isolation/generate_isolated_rmw_env.py",
     "resources/rmw_isolation/package.BUILD.bazel",
@@ -25,7 +22,6 @@ COMMON_FILES_MANIFEST = [
     "resources/rmw_isolation/test/isolated_talker.cc",
     "resources/rmw_isolation/test/isolated_talker.py",
     "resources/rmw_isolation/test/rmw_isolation_test.sh",
-
     "resources/ros2bzl/__init__.py",
     "resources/ros2bzl/resources.py",
     "resources/ros2bzl/sandboxing.py",
@@ -36,7 +32,6 @@ COMMON_FILES_MANIFEST = [
     "resources/ros2bzl/scraping/system.py",
     "resources/ros2bzl/templates.py",
     "resources/ros2bzl/utilities.py",
-
     "resources/templates/ament_cmake_CMakeLists.txt.in",
     "resources/templates/distro.bzl.tpl",
     "resources/templates/overlay_executable.bazel.tpl",
@@ -49,7 +44,6 @@ COMMON_FILES_MANIFEST = [
     "resources/templates/package_share_filegroup.bazel.tpl",
     "resources/templates/prologue.bazel",
     "resources/templates/run.bash.in",
-
     "tools/ament_index.bzl",
     "tools/common.bzl",
     "tools/dload.bzl",
@@ -91,27 +85,29 @@ def base_ros2_repository(repo_ctx, workspaces):
         "run.bash",
         repo_ctx.attr._run_template_file,
         substitutions = {"@WORKSPACES@": " ".join(workspaces)},
-        executable = True
+        executable = True,
     )
 
-    env = {'PYTHONPATH': 'resources/'}
+    env = {"PYTHONPATH": "resources/"}
 
     repo_ctx.report_progress("Generating distro_metadata.json")
     path_to_scrape_distribution_tool = repo_ctx.path(
-        repo_ctx.attr._scrape_distribution_tool)
+        repo_ctx.attr._scrape_distribution_tool,
+    )
     cmd = ["./run.bash", str(path_to_scrape_distribution_tool)]
     for package in repo_ctx.attr.include_packages:
         cmd.extend(["-i", package])
     for package in repo_ctx.attr.exclude_packages:
         cmd.extend(["-e", package])
     cmd.extend(["-o", "distro_metadata.json"])
-    result = execute_or_fail(repo_ctx, cmd, quiet=True, environment=env)
+    result = execute_or_fail(repo_ctx, cmd, quiet = True, environment = env)
     if result.stderr:
         print(result.stderr)
 
     repo_ctx.report_progress("Generating distro.bzl")
     path_to_generate_distro_file_tool = repo_ctx.path(
-        repo_ctx.attr._generate_distro_file_tool)
+        repo_ctx.attr._generate_distro_file_tool,
+    )
     cmd = ["./run.bash", str(path_to_generate_distro_file_tool)]
     for path, path_in_sandbox in workspaces.items():
         cmd.extend(["-s", path + ":" + path_in_sandbox])
@@ -119,13 +115,14 @@ def base_ros2_repository(repo_ctx, workspaces):
     cmd.extend(["-o", "distro.bzl"])
     if repo_ctx.attr.default_localhost_only:
         cmd.extend(["--default-localhost-only"])
-    result = execute_or_fail(repo_ctx, cmd, quiet=True, environment=env)
+    result = execute_or_fail(repo_ctx, cmd, quiet = True, environment = env)
     if result.stderr:
         print(result.stderr)
 
     repo_ctx.report_progress("Generating BUILD.bazel")
     path_to_generate_build_file_tool = repo_ctx.path(
-        repo_ctx.attr._generate_build_file_tool)
+        repo_ctx.attr._generate_build_file_tool,
+    )
     cmd = ["./run.bash", str(path_to_generate_build_file_tool)]
     for path, path_in_sandbox in workspaces.items():
         cmd.extend(["-s", path + ":" + path_in_sandbox])
@@ -133,16 +130,17 @@ def base_ros2_repository(repo_ctx, workspaces):
         cmd.extend(["-j", repr(repo_ctx.attr.jobs)])
     cmd.extend(["-d", "distro_metadata.json", repo_ctx.name])
     cmd.extend(["-o", "BUILD.bazel"])
-    result = execute_or_fail(repo_ctx, cmd, quiet=True, environment=env)
+    result = execute_or_fail(repo_ctx, cmd, quiet = True, environment = env)
     if result.stderr:
         print(result.stderr)
 
     repo_ctx.report_progress("Generating system-rosdep-keys.txt")
     path_to_compute_system_rosdeps_tool = repo_ctx.path(
-        repo_ctx.attr._compute_system_rosdeps_tool)
+        repo_ctx.attr._compute_system_rosdeps_tool,
+    )
     cmd = [str(path_to_compute_system_rosdeps_tool)] + list(workspaces.keys())
     cmd.extend(["-o", "system-rosdep-keys.txt"])
-    result = execute_or_fail(repo_ctx, cmd, quiet=True)
+    result = execute_or_fail(repo_ctx, cmd, quiet = True)
     if result.stderr:
         print(result.stderr)
 
@@ -156,21 +154,21 @@ def base_ros2_repository_attrs():
     return {
         "include_packages": attr.string_list(
             doc = "Optional set of packages to include, " +
-            "with its recursive dependencies. Defaults to all."
+                  "with its recursive dependencies. Defaults to all.",
         ),
         "exclude_packages": attr.string_list(
             doc = "Optional set of packages to exclude, " +
-            "with precedence over included packages. Defaults to none."
+                  "with precedence over included packages. Defaults to none.",
         ),
         "jobs": attr.int(
             doc = "Number of CMake jobs to use during package " +
-            "configuration and scrapping. Defaults to using all cores.",
-            default=0,
+                  "configuration and scrapping. Defaults to using all cores.",
+            default = 0,
         ),
         "default_localhost_only": attr.bool(
             doc = "Whether ROS communication should be restricted to " +
-            "localhost by default. Defaults to True",
-            default=True,
+                  "localhost by default. Defaults to True",
+            default = True,
         ),
         # NOTE: all these labels are listed as private attributes to force prefetching, or else
         # repository rules will be restarted on first hit.
@@ -178,35 +176,35 @@ def base_ros2_repository_attrs():
         # and https://github.com/bazelbuild/bazel/issues/4533 for further reference.
         "_common_files": attr.label_list(
             default = [_label(path) for path in COMMON_FILES_MANIFEST],
-            doc = "List of common files to be symlinked to every new repository."
+            doc = "List of common files to be symlinked to every new repository.",
         ),
         "_run_template_file": attr.label(
             default = _label("resources/templates/run.bash.in"),
             doc = "Template script file to run executables " +
-            "in distribution environments."
+                  "in distribution environments.",
         ),
         "_scrape_distribution_tool": attr.label(
             default = _label("scrape_distribution.py"),
-            doc = "Tool to scrape target distribution metadata."
+            doc = "Tool to scrape target distribution metadata.",
         ),
         "_generate_distro_file_tool": attr.label(
             default = _label("generate_distro_file.py"),
-            doc = "Tool to generate distro.bzl file from distribution metadata."
+            doc = "Tool to generate distro.bzl file from distribution metadata.",
         ),
         "_generate_build_file_tool": attr.label(
             default = _label("generate_build_file.py"),
-            doc = "Tool to generate BUILD.bazel file from distribution metadata."
+            doc = "Tool to generate BUILD.bazel file from distribution metadata.",
         ),
         "_compute_system_rosdeps_tool": attr.label(
             default = _label("compute_system_rosdeps.py"),
-            doc = "Tool to compute system rosdep keys for target distribution."
+            doc = "Tool to compute system rosdep keys for target distribution.",
         ),
     }
 
 _ros2_local_repository_attrs = {
     "workspaces": attr.string_list(
         doc = "Paths to ROS 2 workspace install trees. " +
-        "Each workspace specified overlays the previous one.",
+              "Each workspace specified overlays the previous one.",
         mandatory = True,
     ),
 }
@@ -242,16 +240,16 @@ _ros2_archive_attrs = {
     ),
     "sha256_url": attr.string(
         doc = "The URL to fetch the SHA-256 checksum file for the tarball. " +
-            "If 'sha256' is also supplied, then it must exactly match the " +
-            "value fetched from this URL. " +
-            "(In general, you may only want to supply one of these.)",
+              "If 'sha256' is also supplied, then it must exactly match the " +
+              "value fetched from this URL. " +
+              "(In general, you may only want to supply one of these.)",
     ),
     "strip_prefix": attr.string(
         doc = "A directory prefix to strip from the extracted files.",
     ),
     "type": attr.string(
         doc = "The archive type of the downloaded file. " +
-        "Determined from the file extension by default.",
+              "Determined from the file extension by default.",
     ),
     "patches": attr.label_list(
         doc = "A list of files that are to be applied as patches",
@@ -259,8 +257,8 @@ _ros2_archive_attrs = {
     ),
     "patch_tool": attr.string(
         doc = "The patch(1) utility to use. " +
-        "Uses Bazel native-patch implementation by default.",
-        default = ""
+              "Uses Bazel native-patch implementation by default.",
+        default = "",
     ),
     "patch_args": attr.string_list(
         doc = "The arguments given to the patch tool. Defaults to -p0.",
@@ -268,7 +266,7 @@ _ros2_archive_attrs = {
     ),
     "patch_cmds": attr.string_list(
         doc = "Sequence of Bash commands to be applied on " +
-        "Linux after patches are applied.",
+              "Linux after patches are applied.",
         default = [],
     ),
 }
@@ -279,9 +277,9 @@ def _ros2_archive_impl(repo_ctx):
     if repo_ctx.attr.sha256_url:
         checksum_download_info = repo_ctx.download(
             repo_ctx.attr.sha256_url,
-            "archive.sha256"
+            "archive.sha256",
         )
-        sha256_file = repo_ctx.read("archive.sha256").split(' ', 1)[0]
+        sha256_file = repo_ctx.read("archive.sha256").split(" ", 1)[0]
         if sha256 and sha256 != sha256_file:
             fail("sha256 and sha256_url are both supplied and are different")
         sha256 = sha256_file
@@ -292,23 +290,25 @@ def _ros2_archive_impl(repo_ctx):
         "archive",
         sha256,
         repo_ctx.attr.type,
-        repo_ctx.attr.strip_prefix
+        repo_ctx.attr.strip_prefix,
     )
     patch(repo_ctx)
 
-    workspaces_in_sandbox =  {
-        str(repo_ctx.path("archive")): "archive"}
+    workspaces_in_sandbox = {
+        str(repo_ctx.path("archive")): "archive",
+    }
     base_ros2_repository(repo_ctx, workspaces_in_sandbox)
 
     return update_attrs(
-        repo_ctx.attr, _ros2_archive_attrs.keys(),
-        {"sha256": download_info.sha256}
+        repo_ctx.attr,
+        _ros2_archive_attrs.keys(),
+        {"sha256": download_info.sha256},
     )
 
 ros2_archive = repository_rule(
     attrs = _ros2_archive_attrs,
     implementation = _ros2_archive_impl,
-doc = """
+    doc = """
 Dowloads a ROS 2 distribution as a tarball,
 extracts it, scrapes it, and binds it to a
 Bazel repository.

--- a/bazel_ros2_rules/ros2/ros_cc.bzl
+++ b/bazel_ros2_rules/ros2/ros_cc.bzl
@@ -2,12 +2,12 @@
 
 load(
     "//tools:dload_cc.bzl",
-    "dload_cc_shim"
+    "dload_cc_shim",
 )
 load(
     "//tools:kwargs.bzl",
     "filter_to_only_common_kwargs",
-    "remove_test_specific_kwargs"
+    "remove_test_specific_kwargs",
 )
 load(
     "//tools:common.bzl",
@@ -16,12 +16,14 @@ load(
 load("//tools:ament_index.bzl", "AmentIndex")
 load(
     ":distro.bzl",
-    "RUNTIME_ENVIRONMENT"
+    "RUNTIME_ENVIRONMENT",
 )
 
 def ros_cc_binary(
-    name, rmw_implementation = None, cc_binary_rule = native.cc_binary, **kwargs
-):
+        name,
+        rmw_implementation = None,
+        cc_binary_rule = native.cc_binary,
+        **kwargs):
     """
     Builds a C/C++ binary and wraps it with a shim that will inject the minimal
     runtime environment necessary for execution when depending on targets from
@@ -47,8 +49,9 @@ def ros_cc_binary(
     if rmw_implementation:
         noshim_kwargs, shim_env_changes = \
             incorporate_rmw_implementation(
-                noshim_kwargs, shim_env_changes,
-                rmw_implementation = rmw_implementation
+                noshim_kwargs,
+                shim_env_changes,
+                rmw_implementation = rmw_implementation,
             )
 
     cc_binary_rule(
@@ -69,15 +72,16 @@ def ros_cc_binary(
         srcs = [shim_name],
         data = [":" + noshim_name],
         deps = ["@bazel_tools//tools/cpp/runfiles"],
-        tags = ["nolint"] + kwargs.get("tags", [])
+        tags = ["nolint"] + kwargs.get("tags", []),
     )
     cc_binary_rule(name = name, **kwargs)
 
 def ros_cc_test(
-    name, rmw_implementation = None,
-    cc_binary_rule = native.cc_binary,
-    cc_test_rule = native.cc_test, **kwargs
-):
+        name,
+        rmw_implementation = None,
+        cc_binary_rule = native.cc_binary,
+        cc_test_rule = native.cc_test,
+        **kwargs):
     """
     Builds a C/C++ test and wraps it with a shim that will inject the minimal
     runtime environment necessary for execution when depending on targets from
@@ -101,8 +105,9 @@ def ros_cc_test(
     if rmw_implementation:
         noshim_kwargs, test_env_changes = \
             incorporate_rmw_implementation(
-                noshim_kwargs, shim_env_changes,
-                rmw_implementation = rmw_implementation
+                noshim_kwargs,
+                shim_env_changes,
+                rmw_implementation = rmw_implementation,
             )
 
     cc_binary_rule(
@@ -124,6 +129,6 @@ def ros_cc_test(
         srcs = [shim_name],
         data = [":" + noshim_name],
         deps = ["@bazel_tools//tools/cpp/runfiles"],
-        tags = ["nolint"] + kwargs.get("tags", [])
+        tags = ["nolint"] + kwargs.get("tags", []),
     )
     cc_test_rule(name = name, **kwargs)

--- a/bazel_ros2_rules/ros2/ros_cc.bzl
+++ b/bazel_ros2_rules/ros2/ros_cc.bzl
@@ -13,6 +13,7 @@ load(
     "//tools:common.bzl",
     "incorporate_rmw_implementation",
 )
+load("//tools:ament_index.bzl", "AmentIndex")
 load(
     ":distro.bzl",
     "RUNTIME_ENVIRONMENT"

--- a/bazel_ros2_rules/ros2/rosidl.bzl
+++ b/bazel_ros2_rules/ros2/rosidl.bzl
@@ -167,7 +167,7 @@ def _rosidl_generate_ament_index_entry_impl(ctx):
 
     # Declare interface files in a file under the rosidl_interfaces resource.
     # Directory names are important.
-    # https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/
+    # https://github.com/ament/ament_cmake/blob/1.5.0/ament_cmake_core/
     # doc/resource_index.md#file-system-index-layout
     manifest_path = paths.join(
         ctx.attr.prefix,

--- a/bazel_ros2_rules/ros2/rosidl.bzl
+++ b/bazel_ros2_rules/ros2/rosidl.bzl
@@ -6,11 +6,11 @@ load("//tools:ament_index.bzl", "AmentIndex")
 load(
     ":distro.bzl",
     "AVAILABLE_TYPESUPPORT_LIST",
-    "REPOSITORY_ROOT"
+    "REPOSITORY_ROOT",
 )
 load(
     ":_calculate_rosidl_capitalization.bzl",
-    "calculate_rosidl_capitalization"
+    "calculate_rosidl_capitalization",
 )
 
 RosInterfaces = provider(
@@ -43,24 +43,31 @@ def _rosidl_generate_genrule_impl(ctx):
     args = ctx.actions.args()
     args.add("generate")
     output_path_parts = [
-        ctx.var["GENDIR"], ctx.label.workspace_root,
-        ctx.label.package, ctx.attr.output_dir]
+        ctx.var["GENDIR"],
+        ctx.label.workspace_root,
+        ctx.label.package,
+        ctx.attr.output_dir,
+    ]
     output_path = "/".join([
-        part for part in output_path_parts if part])
+        part
+        for part in output_path_parts
+        if part
+    ])
     args.add("--output-path", output_path)
     for type in ctx.attr.types:
         args.add("--type", type)
     for typesupport in ctx.attr.typesupports:
         args.add("--type-support", typesupport)
-    args.add_all(ctx.files.includes, map_each=_as_include_flag, uniquify=True)
+    args.add_all(ctx.files.includes, map_each = _as_include_flag, uniquify = True)
     args.add(ctx.attr.group)
-    args.add_all(ctx.files.interfaces, map_each=_as_idl_tuple)
+    args.add_all(ctx.files.interfaces, map_each = _as_idl_tuple)
     inputs = ctx.files.interfaces + ctx.files.includes
     ctx.actions.run_shell(
         tools = [ctx.executable._tool],
-        arguments = [args], inputs = inputs,
+        arguments = [args],
+        inputs = inputs,
         command = "{} $@ > /dev/null".format(
-            ctx.executable._tool.path
+            ctx.executable._tool.path,
         ),
         outputs = ctx.outputs.generated_sources,
     )
@@ -72,14 +79,16 @@ rosidl_generate_genrule = rule(
         typesupports = attr.string_list(mandatory = False),
         group = attr.string(mandatory = True),
         interfaces = attr.label_list(
-            mandatory = True, allow_files = True
+            mandatory = True,
+            allow_files = True,
         ),
         includes = attr.label_list(mandatory = False),
         output_dir = attr.string(mandatory = False),
         _tool = attr.label(
             default = REPOSITORY_ROOT + ":rosidl",
-            executable = True, cfg = "exec"
-        )
+            executable = True,
+            cfg = "exec",
+        ),
     ),
     implementation = _rosidl_generate_genrule_impl,
     output_to_genfiles = True,
@@ -103,25 +112,32 @@ def _rosidl_translate_genrule_impl(ctx):
     args = ctx.actions.args()
     args.add("translate")
     output_path_parts = [
-        ctx.var["GENDIR"], ctx.label.workspace_root,
-        ctx.label.package, ctx.attr.output_dir]
+        ctx.var["GENDIR"],
+        ctx.label.workspace_root,
+        ctx.label.package,
+        ctx.attr.output_dir,
+    ]
     output_path = "/".join([
-        part for part in output_path_parts if part])
+        part
+        for part in output_path_parts
+        if part
+    ])
     args.add("--output-path", output_path)
     args.add("--output-format", ctx.attr.output_format)
     if ctx.attr.input_format:
         args.add("--input-format", ctx.attr.input_format)
-    args.add_all(ctx.files.includes, map_each=_as_include_flag, uniquify=True)
+    args.add_all(ctx.files.includes, map_each = _as_include_flag, uniquify = True)
     args.add(ctx.attr.group)
-    args.add_all(ctx.files.interfaces, map_each=_as_idl_tuple)
+    args.add_all(ctx.files.interfaces, map_each = _as_idl_tuple)
     inputs = ctx.files.interfaces + ctx.files.includes
     ctx.actions.run_shell(
         tools = [ctx.executable._tool],
-        arguments = [args], inputs = inputs,
+        arguments = [args],
+        inputs = inputs,
         command = "{} $@ > /dev/null".format(
-            ctx.executable._tool.path
+            ctx.executable._tool.path,
         ),
-        outputs = ctx.outputs.translated_interfaces
+        outputs = ctx.outputs.translated_interfaces,
     )
     return [RosInterfaces(interfaces = ctx.files.interfaces + ctx.outputs.translated_interfaces)]
 
@@ -132,14 +148,16 @@ rosidl_translate_genrule = rule(
         input_format = attr.string(mandatory = False),
         group = attr.string(mandatory = True),
         interfaces = attr.label_list(
-            mandatory = True, allow_files = True
+            mandatory = True,
+            allow_files = True,
         ),
         includes = attr.label_list(mandatory = False),
         output_dir = attr.string(mandatory = False),
         _tool = attr.label(
             default = REPOSITORY_ROOT + ":rosidl",
-            executable = True, cfg = "exec"
-        )
+            executable = True,
+            cfg = "exec",
+        ),
     ),
     implementation = _rosidl_translate_genrule_impl,
     output_to_genfiles = True,
@@ -163,13 +181,13 @@ def _rosidl_generate_ament_index_entry_impl(ctx):
     # declare that a "package" with the group name exists
     package_marker_path = paths.join(
         ctx.attr.prefix,
-        'share/ament_index/resource_index/packages/',
+        "share/ament_index/resource_index/packages/",
         ctx.attr.group,
     )
     package_marker_out = ctx.actions.declare_file(package_marker_path)
     ctx.actions.write(
         output = package_marker_out,
-        content = ""
+        content = "",
     )
 
     # Declare interface files in a file under the rosidl_interfaces resource.
@@ -178,7 +196,7 @@ def _rosidl_generate_ament_index_entry_impl(ctx):
     # doc/resource_index.md#file-system-index-layout
     manifest_path = paths.join(
         ctx.attr.prefix,
-        'share/ament_index/resource_index/rosidl_interfaces/',
+        "share/ament_index/resource_index/rosidl_interfaces/",
         ctx.attr.group,
     )
     manifest_out = ctx.actions.declare_file(manifest_path)
@@ -201,23 +219,27 @@ def _rosidl_generate_ament_index_entry_impl(ctx):
 
     ctx.actions.write(
         output = manifest_out,
-        content = "\n".join(sorted(rosidl_interfaces_manifest))
+        content = "\n".join(sorted(rosidl_interfaces_manifest)),
     )
 
     # Symlink interface files into the share directory
     runfiles_symlinks = {
-      package_marker_path: package_marker_out,
-      manifest_path: manifest_out
+        package_marker_path: package_marker_out,
+        manifest_path: manifest_out,
     }
     for path, short_path in zip(interface_files, rosidl_interfaces_manifest):
         symlink_path = paths.join(
-            ctx.attr.prefix, "share", ctx.attr.group, short_path)
+            ctx.attr.prefix,
+            "share",
+            ctx.attr.group,
+            short_path,
+        )
         runfiles_symlinks[symlink_path] = path
 
     return [
         AmentIndex(prefix = ctx.attr.prefix),
         DefaultInfo(
-            runfiles = ctx.runfiles(root_symlinks = runfiles_symlinks)
+            runfiles = ctx.runfiles(root_symlinks = runfiles_symlinks),
         ),
     ]
 
@@ -225,7 +247,10 @@ rosidl_generate_ament_index_entry = rule(
     attrs = dict(
         group = attr.string(mandatory = True),
         definitions_deps = attr.label_list(
-            mandatory = True, allow_empty = False, allow_files = True),
+            mandatory = True,
+            allow_empty = False,
+            allow_files = True,
+        ),
         prefix = attr.string(default = "."),
     ),
     implementation = _rosidl_generate_ament_index_entry_impl,
@@ -308,14 +333,14 @@ def _deduce_source_paths(group, kind):
     root = "{}/{}".format(include, group)
     return include, root
 
-def _make_public_name(name, suffix=""):
+def _make_public_name(name, suffix = ""):
     """
     Builds a public name (i.e. with no leading underscore) from a
     private or public name.
     """
     return name.lstrip("_") + suffix
 
-def _make_private_name(name, suffix=""):
+def _make_private_name(name, suffix = ""):
     """
     Builds a private name (i.e. with leading underscore) from a
     private or public name.
@@ -324,7 +349,7 @@ def _make_private_name(name, suffix=""):
         name = "_" + name
     return name + suffix
 
-def _make_public_label(label, suffix=""):
+def _make_public_label(label, suffix = ""):
     """
     Builds a public label (i.e. name with no leading underscore)
     from a private or public label, or a plain name (assumed to
@@ -336,7 +361,7 @@ def _make_public_label(label, suffix=""):
         prefix = prefix + "/"
     return package + ":" + prefix + _make_public_name(name, suffix)
 
-def _make_private_label(label, suffix=""):
+def _make_private_label(label, suffix = ""):
     """
     Builds a private label (i.e. name with leading underscore)
     from a private or public label, or a plain name (assumed to
@@ -349,9 +374,13 @@ def _make_private_label(label, suffix=""):
     return package + ":" + prefix + _make_private_name(name, suffix)
 
 def rosidl_c_library(
-    name, group, interfaces, includes = [], deps = [],
-    cc_library_rule = native.cc_library, **kwargs
-):
+        name,
+        group,
+        interfaces,
+        includes = [],
+        deps = [],
+        cc_library_rule = native.cc_library,
+        **kwargs):
     """
     Generates and builds C ROS 2 interfaces.
 
@@ -406,9 +435,13 @@ def rosidl_c_library(
     )
 
 def rosidl_cc_library(
-    name, group, interfaces, includes = [], deps = [],
-    cc_library_rule = native.cc_library, **kwargs
-):
+        name,
+        group,
+        interfaces,
+        includes = [],
+        deps = [],
+        cc_library_rule = native.cc_library,
+        **kwargs):
     """
     Generates and builds C++ ROS 2 interfaces.
 
@@ -448,7 +481,7 @@ def rosidl_cc_library(
         hdrs = generated_cc_headers,
         includes = [include],
         deps = deps + [
-            REPOSITORY_ROOT + ":rosidl_runtime_cpp_cc"
+            REPOSITORY_ROOT + ":rosidl_runtime_cpp_cc",
         ],
         **kwargs
     )
@@ -457,13 +490,17 @@ def _make_c_typesupport_extension_name(group, typesupport_name):
     return "{}_s__{}".format(group, typesupport_name) + PYTHON_EXTENSION_SUFFIX
 
 def rosidl_py_library(
-    name, group, interfaces, typesupports,
-    includes = [], c_deps = [], py_deps = [],
-    cc_binary_rule = native.cc_binary,
-    cc_library_rule = native.cc_library,
-    py_library_rule = native.py_library,
-    **kwargs
-):
+        name,
+        group,
+        interfaces,
+        typesupports,
+        includes = [],
+        c_deps = [],
+        py_deps = [],
+        cc_binary_rule = native.cc_binary,
+        cc_library_rule = native.cc_library,
+        py_library_rule = native.py_library,
+        **kwargs):
     """
     Generates and builds Python ROS 2 interfaces, including any C extensions.
 
@@ -493,15 +530,18 @@ def rosidl_py_library(
         if py_source not in generated_py_sources:
             generated_py_sources.append(py_source)
         generated_py_sources.append(
-            "{}/{}/_{}.py".format(root, parent, basename))
+            "{}/{}/_{}.py".format(root, parent, basename),
+        )
         generated_c_sources.append(
-            "{}/{}/_{}_s.c".format(root, parent, basename))
+            "{}/{}/_{}_s.c".format(root, parent, basename),
+        )
     generated_sources = generated_c_sources + generated_py_sources
 
     generated_c_sources_per_typesupport = {}
     for typesupport_name in typesupports:
         generated_c_sources_per_typesupport[typesupport_name] = [
-            "{}/_{}_s.ep.{}.c".format(root, group, typesupport_name)]
+            "{}/_{}_s.ep.{}.c".format(root, group, typesupport_name),
+        ]
         generated_sources += generated_c_sources_per_typesupport[typesupport_name]
 
     rosidl_generate_genrule(
@@ -509,7 +549,7 @@ def rosidl_py_library(
         generated_sources = generated_sources,
         types = [
             "py[typesupport_implementations:[{}]]"
-            .format(",".join(typesupports))
+                .format(",".join(typesupports)),
         ],
         group = group,
         interfaces = interfaces,
@@ -522,7 +562,8 @@ def rosidl_py_library(
         name = _make_private_name(name, "_c"),
         srcs = generated_c_sources,
         deps = c_deps + [
-            _make_private_label(dep, "_c") for dep in py_deps
+            _make_private_label(dep, "_c")
+            for dep in py_deps
         ] + ["@python_dev//:libs"],
         **kwargs
     )
@@ -541,11 +582,15 @@ def rosidl_py_library(
         if typesupport_library not in deps:
             deps.append(typesupport_library)
         c_typesupport_extension = "{}/{}".format(
-            root, _make_c_typesupport_extension_name(group, typesupport_name))
+            root,
+            _make_c_typesupport_extension_name(group, typesupport_name),
+        )
         cc_binary_rule(
             name = c_typesupport_extension,
             srcs = generated_c_sources_per_typesupport[typesupport_name],
-            deps = deps, linkshared = True, **kwargs
+            deps = deps,
+            linkshared = True,
+            **kwargs
         )
         py_data.append(c_typesupport_extension)
 
@@ -559,10 +604,14 @@ def rosidl_py_library(
     )
 
 def rosidl_typesupport_fastrtps_cc_library(
-    name, group, interfaces, includes = [], deps = [],
-    cc_binary_rule = native.cc_binary, cc_library_rule = native.cc_library,
-    **kwargs
-):
+        name,
+        group,
+        interfaces,
+        includes = [],
+        deps = [],
+        cc_binary_rule = native.cc_binary,
+        cc_library_rule = native.cc_library,
+        **kwargs):
     """
     Generates and builds FastRTPS C++ typesupport for ROS 2 interfaces.
 
@@ -625,10 +674,14 @@ def rosidl_typesupport_fastrtps_cc_library(
     )
 
 def rosidl_typesupport_fastrtps_c_library(
-    name, group, interfaces, includes = [], deps = [],
-    cc_binary_rule = native.cc_binary, cc_library_rule = native.cc_library,
-    **kwargs
-):
+        name,
+        group,
+        interfaces,
+        includes = [],
+        deps = [],
+        cc_binary_rule = native.cc_binary,
+        cc_library_rule = native.cc_library,
+        **kwargs):
     """
     Generates and builds FastRTPS C typesupport for ROS 2 interfaces.
 
@@ -692,10 +745,14 @@ def rosidl_typesupport_fastrtps_c_library(
     )
 
 def rosidl_typesupport_introspection_c_library(
-    name, group, interfaces, includes = [], deps = [],
-    cc_binary_rule = native.cc_binary, cc_library_rule = native.cc_library,
-    **kwargs
-):
+        name,
+        group,
+        interfaces,
+        includes = [],
+        deps = [],
+        cc_binary_rule = native.cc_binary,
+        cc_library_rule = native.cc_library,
+        **kwargs):
     """
     Generates and builds C introspection typesupport for ROS 2 interfaces.
 
@@ -718,7 +775,8 @@ def rosidl_typesupport_introspection_c_library(
     for ifc in interfaces:
         parent, basename = _deduce_source_parts(ifc)
         generated_c_sources.append(
-            "{}/{}/detail/{}__type_support.c".format(root, parent, basename))
+            "{}/{}/detail/{}__type_support.c".format(root, parent, basename),
+        )
         template = "{}/{}/detail/{}__rosidl_typesupport_introspection_c.h"
         generated_c_headers.append(template.format(root, parent, basename))
     generated_sources = generated_c_sources + generated_c_headers
@@ -754,10 +812,14 @@ def rosidl_typesupport_introspection_c_library(
     )
 
 def rosidl_typesupport_introspection_cc_library(
-    name, group, interfaces, includes = [], deps = [],
-    cc_binary_rule = native.cc_binary, cc_library_rule = native.cc_library,
-    **kwargs
-):
+        name,
+        group,
+        interfaces,
+        includes = [],
+        deps = [],
+        cc_binary_rule = native.cc_binary,
+        cc_library_rule = native.cc_library,
+        **kwargs):
     """
     Generates and builds C++ introspection typesupport for ROS 2 interfaces.
 
@@ -779,7 +841,8 @@ def rosidl_typesupport_introspection_cc_library(
     for ifc in interfaces:
         parent, basename = _deduce_source_parts(ifc)
         generated_cc_sources.append(
-            "{}/{}/detail/{}__type_support.cpp".format(root, parent, basename))
+            "{}/{}/detail/{}__type_support.cpp".format(root, parent, basename),
+        )
         template = "{}/{}/detail/{}__rosidl_typesupport_introspection_cpp.hpp"
         generated_cc_headers.append(template.format(root, parent, basename))
     generated_sources = generated_cc_sources + generated_cc_headers
@@ -818,9 +881,14 @@ def rosidl_typesupport_introspection_cc_library(
     )
 
 def rosidl_typesupport_c_library(
-    name, group, interfaces, typesupports, includes = [],
-    deps = [], cc_binary_rule = native.cc_binary, **kwargs
-):
+        name,
+        group,
+        interfaces,
+        typesupports,
+        includes = [],
+        deps = [],
+        cc_binary_rule = native.cc_binary,
+        **kwargs):
     """
     Generates and builds ROS 2 interfaces' C typesupport.
 
@@ -844,7 +912,8 @@ def rosidl_typesupport_c_library(
     for ifc in interfaces:
         parent, basename = _deduce_source_parts(ifc)
         generated_c_sources.append(
-            "{}/{}/{}__type_support.cpp".format(root, parent, basename))
+            "{}/{}/{}__type_support.cpp".format(root, parent, basename),
+        )
     generated_sources = generated_c_sources + generated_c_headers
 
     rosidl_generate_genrule(
@@ -852,7 +921,7 @@ def rosidl_typesupport_c_library(
         generated_sources = generated_sources,
         typesupports = [
             "c[typesupport_implementations:[{}]]"
-            .format(",".join(typesupports))
+                .format(",".join(typesupports)),
         ],
         group = group,
         interfaces = interfaces,
@@ -879,9 +948,14 @@ def rosidl_typesupport_c_library(
     )
 
 def rosidl_typesupport_cc_library(
-    name, group, interfaces, typesupports, includes = [],
-    deps = [], cc_binary_rule = native.cc_binary, **kwargs
-):
+        name,
+        group,
+        interfaces,
+        typesupports,
+        includes = [],
+        deps = [],
+        cc_binary_rule = native.cc_binary,
+        **kwargs):
     """
     Generates and builds ROS 2 interfaces' C++ typesupport.
 
@@ -904,14 +978,15 @@ def rosidl_typesupport_cc_library(
     for ifc in interfaces:
         parent, basename = _deduce_source_parts(ifc)
         generated_cc_sources.append(
-            "{}/{}/{}__type_support.cpp".format(root, parent, basename))
+            "{}/{}/{}__type_support.cpp".format(root, parent, basename),
+        )
 
     rosidl_generate_genrule(
         name = _make_private_name(name, "_gen"),
         generated_sources = generated_cc_sources,
         typesupports = [
             "cpp[typesupport_implementations:[{}]]"
-            .format(",".join(typesupports))
+                .format(",".join(typesupports)),
         ],
         group = group,
         interfaces = interfaces,
@@ -939,11 +1014,13 @@ def rosidl_typesupport_cc_library(
     )
 
 def rosidl_cc_support(
-    name, interfaces, deps, group = None,
-    cc_binary_rule = native.cc_binary,
-    cc_library_rule = native.cc_library,
-    **kwargs
-):
+        name,
+        interfaces,
+        deps,
+        group = None,
+        cc_binary_rule = native.cc_binary,
+        cc_library_rule = native.cc_library,
+        **kwargs):
     """
     Generates and builds C++ ROS 2 interfaces.
 
@@ -972,6 +1049,7 @@ def rosidl_cc_support(
     )
 
     typesupports = {}
+
     # NOTE: typesupport binary files must not have any leading
     # underscores or C++ generated code will not be able to
     # dlopen it.
@@ -982,7 +1060,9 @@ def rosidl_cc_support(
             interfaces = interfaces,
             includes = [_make_public_label(dep, "_defs") for dep in deps],
             deps = [_make_private_label(name, "__rosidl_cpp")] + [
-                _make_public_label(dep, "_cc") for dep in deps],
+                _make_public_label(dep, "_cc")
+                for dep in deps
+            ],
             cc_binary_rule = cc_binary_rule,
             cc_library_rule = cc_library_rule,
             **kwargs
@@ -997,12 +1077,14 @@ def rosidl_cc_support(
             interfaces = interfaces,
             includes = [_make_public_label(dep, "_defs") for dep in deps],
             deps = [_make_private_label(name, "__rosidl_cpp")] + [
-                _make_public_label(dep, "_cc") for dep in deps],
+                _make_public_label(dep, "_cc")
+                for dep in deps
+            ],
             cc_binary_rule = cc_binary_rule,
             cc_library_rule = cc_library_rule,
             **kwargs
         )
-        typesupports["rosidl_typesupport_fastrtps_cpp"] =  \
+        typesupports["rosidl_typesupport_fastrtps_cpp"] = \
             _make_public_label(name, "__rosidl_typesupport_fastrtps_cpp")
 
     rosidl_typesupport_cc_library(
@@ -1012,7 +1094,9 @@ def rosidl_cc_support(
         interfaces = interfaces,
         includes = [_make_public_label(dep, "_defs") for dep in deps],
         deps = [_make_private_label(name, "__rosidl_cpp")] + [
-            _make_public_label(dep, "_cc") for dep in deps],
+            _make_public_label(dep, "_cc")
+            for dep in deps
+        ],
         cc_binary_rule = cc_binary_rule,
         **kwargs
     )
@@ -1020,7 +1104,7 @@ def rosidl_cc_support(
     cc_library_rule(
         name = _make_public_name(name, "_cc"),
         srcs = [
-            _make_public_label(name, "__rosidl_typesupport_cpp")
+            _make_public_label(name, "__rosidl_typesupport_cpp"),
         ] + typesupports.values(),
         deps = [_make_private_label(name, "__rosidl_cpp")],
         linkstatic = True,
@@ -1028,12 +1112,14 @@ def rosidl_cc_support(
     )
 
 def rosidl_py_support(
-    name, interfaces, deps, group = None,
-    cc_binary_rule = native.cc_binary,
-    cc_library_rule = native.cc_library,
-    py_library_rule = native.py_library,
-    **kwargs
-):
+        name,
+        interfaces,
+        deps,
+        group = None,
+        cc_binary_rule = native.cc_binary,
+        cc_library_rule = native.cc_library,
+        py_library_rule = native.py_library,
+        **kwargs):
     """
     Generates and builds Python ROS 2 interfaces.
 
@@ -1063,6 +1149,7 @@ def rosidl_py_support(
     )
 
     typesupports = {}
+
     # NOTE: typesupport binary files must not have any leading
     # underscores or C generated code will not be able to
     # dlopen it.
@@ -1073,7 +1160,9 @@ def rosidl_py_support(
             interfaces = interfaces,
             includes = [_make_public_label(dep, "_defs") for dep in deps],
             deps = [_make_private_label(name, "__rosidl_c")] + [
-                _make_public_label(dep, "_c") for dep in deps],
+                _make_public_label(dep, "_c")
+                for dep in deps
+            ],
             cc_binary_rule = cc_binary_rule,
             cc_library_rule = cc_library_rule,
             **kwargs
@@ -1088,7 +1177,9 @@ def rosidl_py_support(
             interfaces = interfaces,
             includes = [_make_public_label(dep, "_defs") for dep in deps],
             deps = [_make_private_label(name, "__rosidl_c")] + [
-                _make_public_label(dep, "_c") for dep in deps],
+                _make_public_label(dep, "_c")
+                for dep in deps
+            ],
             cc_binary_rule = cc_binary_rule,
             cc_library_rule = cc_library_rule,
             **kwargs
@@ -1103,7 +1194,9 @@ def rosidl_py_support(
         interfaces = interfaces,
         includes = [_make_public_label(dep, "_defs") for dep in deps],
         deps = [_make_private_label(name, "__rosidl_c")] + [
-            _make_public_label(dep, "_c") for dep in deps],
+            _make_public_label(dep, "_c")
+            for dep in deps
+        ],
         cc_binary_rule = cc_binary_rule,
         **kwargs
     )
@@ -1114,7 +1207,7 @@ def rosidl_py_support(
         name = _make_public_name(name, "_c"),
         srcs = typesupports.values(),
         deps = [
-            _make_private_label(name, "__rosidl_c")
+            _make_private_label(name, "__rosidl_c"),
         ] + typesupports.values(),
         linkstatic = True,
         **kwargs
@@ -1128,7 +1221,9 @@ def rosidl_py_support(
         includes = [_make_public_label(dep, "_defs") for dep in deps],
         py_deps = [_make_public_label(dep, "_py") for dep in deps],
         c_deps = [_make_public_label(name, "_c")] + [
-            _make_public_label(dep, "_c") for dep in deps],
+            _make_public_label(dep, "_c")
+            for dep in deps
+        ],
         cc_binary_rule = cc_binary_rule,
         cc_library_rule = cc_library_rule,
         py_library_rule = py_library_rule,
@@ -1136,12 +1231,14 @@ def rosidl_py_support(
     )
 
 def rosidl_interfaces_group(
-    name, interfaces, deps = [], group = None,
-    cc_binary_rule = native.cc_binary,
-    cc_library_rule = native.cc_library,
-    py_library_rule = native.py_library,
-    **kwargs
-):
+        name,
+        interfaces,
+        deps = [],
+        group = None,
+        cc_binary_rule = native.cc_binary,
+        cc_library_rule = native.cc_library,
+        py_library_rule = native.py_library,
+        **kwargs):
     """
     Generates and builds C++ and Python ROS 2 interfaces.
 
@@ -1170,14 +1267,20 @@ def rosidl_interfaces_group(
     )
 
     rosidl_cc_support(
-        name, interfaces, deps, group,
+        name,
+        interfaces,
+        deps,
+        group,
         cc_binary_rule = cc_binary_rule,
         cc_library_rule = cc_library_rule,
         **kwargs
     )
 
     rosidl_py_support(
-        name, interfaces, deps, group,
+        name,
+        interfaces,
+        deps,
+        group,
         cc_binary_rule = cc_binary_rule,
         cc_library_rule = cc_library_rule,
         py_library_rule = py_library_rule,

--- a/bazel_ros2_rules/ros2/rosidl.bzl
+++ b/bazel_ros2_rules/ros2/rosidl.bzl
@@ -1140,7 +1140,7 @@ def rosidl_interfaces_group(
     rosidl_generate_ament_index_entry(
         name = name + "_ament_index",
         group = group or name,
-        interfaces = [name + "_defs"] + interfaces,
+        interfaces = [_make_public_label(name, "_defs")] + interfaces,
     )
 
     rosidl_cc_support(

--- a/bazel_ros2_rules/ros2/tools/ament_index.bzl
+++ b/bazel_ros2_rules/ros2/tools/ament_index.bzl
@@ -3,10 +3,25 @@
 AmentIndex = provider(
     fields = ["prefix"],
 )
+"""
+Provide the location of an ament resource index.
 
-AmentIndexes = provider(
+This provider is intended to be returned by a rule.
+
+See rosidl_generate_ament_index_entry()
+"""
+
+AggregatedAmentIndexes = provider(
     fields = ["prefixes"],
 )
+"""
+Provides the location of multiple ament resource indexes.
+
+This is intended to be aggregated by an aspect, and should not be used by
+rules because it prevents an aspect from aggregating the information again.
+
+See ament_index_prefixes for more info.
+"""
 
 def _ament_index_prefixes_aspect_impl(target, ctx):
     prefixes = []
@@ -14,15 +29,18 @@ def _ament_index_prefixes_aspect_impl(target, ctx):
         prefixes.append(target[AmentIndex].prefix)
     if hasattr(ctx.rule.attr, "data"):
         for data in ctx.rule.attr.data:
-            if AmentIndexes in data:
-                prefixes.extend(data[AmentIndexes].prefixes)
+            if AggregatedAmentIndexes in data:
+                prefixes.extend(data[AggregatedAmentIndexes].prefixes)
     if hasattr(ctx.rule.attr, "deps"):
         for dep in ctx.rule.attr.deps:
-            if AmentIndexes in dep:
-                prefixes.extend(dep[AmentIndexes].prefixes)
-    return [AmentIndexes(prefixes = prefixes)]
+            if AggregatedAmentIndexes in dep:
+                prefixes.extend(dep[AggregatedAmentIndexes].prefixes)
+    return [AggregatedAmentIndexes(prefixes = prefixes)]
 
 ament_index_prefixes = aspect(
-  implementation = _ament_index_prefixes_aspect_impl,
-  attr_aspects = ["deps", "data"],
+    implementation = _ament_index_prefixes_aspect_impl,
+    attr_aspects = ["deps", "data"],
 )
+"""
+Recursively aggregates AmentIndex prefixes from dependencies into one provider.
+"""

--- a/bazel_ros2_rules/ros2/tools/ament_index.bzl
+++ b/bazel_ros2_rules/ros2/tools/ament_index.bzl
@@ -1,0 +1,28 @@
+# -*- python -*-
+
+AmentIndex = provider(
+    fields = ["prefix"],
+)
+
+AmentIndexes = provider(
+    fields = ["prefixes"],
+)
+
+def _ament_index_prefixes_aspect_impl(target, ctx):
+    prefixes = []
+    if AmentIndex in target:
+        prefixes.append(target[AmentIndex].prefix)
+    if hasattr(ctx.rule.attr, "data"):
+        for data in ctx.rule.attr.data:
+            if AmentIndexes in data:
+                prefixes.extend(data[AmentIndexes].prefixes)
+    if hasattr(ctx.rule.attr, "deps"):
+        for dep in ctx.rule.attr.deps:
+            if AmentIndexes in dep:
+                prefixes.extend(dep[AmentIndexes].prefixes)
+    return [AmentIndexes(prefixes = prefixes)]
+
+ament_index_prefixes = aspect(
+  implementation = _ament_index_prefixes_aspect_impl,
+  attr_aspects = ["deps", "data"],
+)

--- a/bazel_ros2_rules/ros2/tools/dload.bzl
+++ b/bazel_ros2_rules/ros2/tools/dload.bzl
@@ -98,7 +98,9 @@ def do_dload_shim(ctx, template, to_list):
     # Add ament resource index paths from targets we depend on
     if AmentIndexes in ctx.attr.target:
         if "AMENT_PREFIX_PATH" not in env_changes:
-            env_changes["AMENT_PREFIX_PATH"] = []
+            env_changes["AMENT_PREFIX_PATH"] = ["path-prepend"]
+        if env_changes["AMENT_PREFIX_PATH"][0] != "path-prepend":
+            fail("failed assumption - AMENT_PREFIX_PATH was not prepended to")
         env_changes["AMENT_PREFIX_PATH"].extend(
           ctx.attr.target[AmentIndexes].prefixes)
 

--- a/bazel_ros2_rules/ros2/tools/dload.bzl
+++ b/bazel_ros2_rules/ros2/tools/dload.bzl
@@ -10,7 +10,7 @@ specific shim generation.
 
 load(
     "//tools:ament_index.bzl",
-    "AmentIndexes",
+    "AggregatedAmentIndexes",
     "ament_index_prefixes",
 )
 
@@ -96,13 +96,13 @@ def do_dload_shim(ctx, template, to_list):
     }
 
     # Add ament resource index paths from targets we depend on
-    if AmentIndexes in ctx.attr.target:
+    if AggregatedAmentIndexes in ctx.attr.target:
         if "AMENT_PREFIX_PATH" not in env_changes:
             env_changes["AMENT_PREFIX_PATH"] = ["path-prepend"]
         if env_changes["AMENT_PREFIX_PATH"][0] != "path-prepend":
             fail("failed assumption - AMENT_PREFIX_PATH was not prepended to")
         env_changes["AMENT_PREFIX_PATH"].extend(
-          ctx.attr.target[AmentIndexes].prefixes)
+          ctx.attr.target[AggregatedAmentIndexes].prefixes)
 
     envvars = env_changes.keys()
     actions = env_changes.values()

--- a/bazel_ros2_rules/ros2/tools/dload.bzl
+++ b/bazel_ros2_rules/ros2/tools/dload.bzl
@@ -15,7 +15,7 @@ load(
 )
 
 MAGIC_VARIABLES = {
-    "${LOAD_PATH}": "LD_LIBRARY_PATH"  # for Linux
+    "${LOAD_PATH}": "LD_LIBRARY_PATH",  # for Linux
 }
 
 def _unique(input_list):
@@ -90,8 +90,7 @@ def do_dload_shim(ctx, template, to_list):
     executable_file = ctx.executable.target
 
     env_changes = {
-        MAGIC_VARIABLES.get(name, default=name):
-        _parse_runtime_environment_action(ctx, action)
+        MAGIC_VARIABLES.get(name, default = name): _parse_runtime_environment_action(ctx, action)
         for name, action in ctx.attr.env_changes.items()
     }
 
@@ -102,21 +101,25 @@ def do_dload_shim(ctx, template, to_list):
         if env_changes["AMENT_PREFIX_PATH"][0] != "path-prepend":
             fail("failed assumption - AMENT_PREFIX_PATH was not prepended to")
         env_changes["AMENT_PREFIX_PATH"].extend(
-          ctx.attr.target[AggregatedAmentIndexes].prefixes)
+            ctx.attr.target[AggregatedAmentIndexes].prefixes,
+        )
 
     envvars = env_changes.keys()
     actions = env_changes.values()
 
     shim_content = template.format(
         # Deal with usage in external workspaces' BUILD.bazel files
-        executable_path=_normpath("{}/{}".format(
-            ctx.workspace_name, executable_file.short_path
+        executable_path = _normpath("{}/{}".format(
+            ctx.workspace_name,
+            executable_file.short_path,
         )),
-        names=to_list([repr(name) for name in envvars]),
-        actions=to_list([
+        names = to_list([repr(name) for name in envvars]),
+        actions = to_list([
             to_list([
-                repr(field) for field in action
-            ]) for action in actions
+                repr(field)
+                for field in action
+            ])
+            for action in actions
         ]),
     )
     shim = ctx.actions.declare_file(ctx.label.name)
@@ -145,8 +148,8 @@ def _parse_runtime_environment_action(ctx, action):
             tpl = "'{}' action requires at least one argument"
             fail(msg = tpl.format(action_type))
         action_args = _unique([
-            _resolve_runfile_path(ctx, path[:-1]) + "!" if path.endswith("!")
-            else _resolve_runfile_path(ctx, path) for path in action_args
+            _resolve_runfile_path(ctx, path[:-1]) + "!" if path.endswith("!") else _resolve_runfile_path(ctx, path)
+            for path in action_args
         ])
     elif action_type in ("path-replace", "set-if-not-set", "replace"):
         if len(action_args) != 1:

--- a/bazel_ros2_rules/ros2/tools/dload_py.bzl
+++ b/bazel_ros2_rules/ros2/tools/dload_py.bzl
@@ -20,6 +20,8 @@ import sys
 
 from bazel_tools.tools.python.runfiles import runfiles
 
+SHIMMED_SENTINEL = "_BAZEL_ROS2_RULES_SHIMMED";
+
 
 def main(argv):
     r = runfiles.Create()
@@ -31,29 +33,31 @@ def main(argv):
     def rlocation(path):
         return r.Rlocation(path) or os.path.join(runfiles_dir, path)
 
-    for name, action in zip({names}, {actions}):  # noqa
-        action_type, action_args = action[0], action[1:]
-        if action_type == 'replace':
-            assert len(action_args) == 1
-            value = action_args[0]
-        elif action_type == 'set-if-not-set':
-            assert len(action_args) == 1
-            if name in os.environ:
-                continue
-            value = action_args[0]
-        elif action_type == 'path-replace':
-            assert len(action_args) == 1
-            value = rlocation(action_args[0])
-        elif action_type == 'path-prepend':
-            assert len(action_args) > 0
-            value = ':'.join([rlocation(path) for path in action_args])
-            if name in os.environ:
-                value += ':' + os.environ[name]
-        else:
-            assert False  # should never get here
-        if '$PWD' in value:
-            value = value.replace('$PWD', os.getcwd())
-        os.environ[name] = value
+    if SHIMMED_SENTINEL not in os.environ:
+        for name, action in zip({names}, {actions}):  # noqa
+            action_type, action_args = action[0], action[1:]
+            if action_type == 'replace':
+                assert len(action_args) == 1
+                value = action_args[0]
+            elif action_type == 'set-if-not-set':
+                assert len(action_args) == 1
+                if name in os.environ:
+                    continue
+                value = action_args[0]
+            elif action_type == 'path-replace':
+                assert len(action_args) == 1
+                value = rlocation(action_args[0])
+            elif action_type == 'path-prepend':
+                assert len(action_args) > 0
+                value = ':'.join([rlocation(path) for path in action_args])
+                if name in os.environ:
+                    value += ':' + os.environ[name]
+            else:
+                assert False  # should never get here
+            if '$PWD' in value:
+                value = value.replace('$PWD', os.getcwd())
+            os.environ[name] = value
+        os.environ[SHIMMED_SENTINEL] = ""
 
     executable_path = r.Rlocation('{executable_path}')  # noqa
     argv = [executable_path] + argv[1:]
@@ -80,6 +84,9 @@ dload_py_shim = rule(
 Generates a Python shim that can inject runtime environment information for
 Python binaries that have such requirements. Using a Python shim for Python
 binaries enables downstream usage of the latter through transitive dependencies.
+
+This shim uses a sentinel environment variable so that it only modifies the
+environment once. Any nested shims will use the top-level shim's environment.
 
 See do_dload_shim() documentation for further reference.
 """

--- a/ros2_example_bazel_installed/BUILD.bazel
+++ b/ros2_example_bazel_installed/BUILD.bazel
@@ -1,7 +1,13 @@
 # -*- python -*-
 
-load("@ros2//:ros_cc.bzl", "ros_cc_test")
-load("@ros2//:ros_py.bzl", "ros_py_test")
+load("@ros2//:ros_cc.bzl",
+    "ros_cc_binary",
+    "ros_cc_test",
+)
+load("@ros2//:ros_py.bzl",
+    "ros_py_binary",
+    "ros_py_test",
+)
 load("//tools:cmd_test.bzl", "cmd_test")
 
 # TODO(hidmic): make linter more user-friendly
@@ -31,4 +37,27 @@ ros_py_test(
     main = "test/runfiles_test.py",
     deps = ["@bazel_tools//tools/python/runfiles"],
     data = ["test/runfiles_test_data.txt"],
+)
+
+ros_cc_binary(
+    name = "shimmed_sentinel_cc",
+    srcs = ["test/shimmed_sentinel.cc"],
+)
+
+ros_py_binary(
+    name = "shimmed_sentinel_py",
+    srcs = ["test/shimmed_sentinel.py"],
+    main = "test/shimmed_sentinel.py",
+)
+
+py_test(
+    name = "shimmed_sentinel_test",
+    srcs = ["test/shimmed_sentinel_test.py"],
+    deps = [
+        "@bazel_tools//tools/python/runfiles"
+    ],
+    data = [
+        ":shimmed_sentinel_cc",
+        ":shimmed_sentinel_py",
+    ],
 )

--- a/ros2_example_bazel_installed/WORKSPACE
+++ b/ros2_example_bazel_installed/WORKSPACE
@@ -7,6 +7,19 @@ environment_repository(
 )
 load("@ros2_example_bazel_installed_environ//:environ.bzl", "ROS2_DISTRO_PREFIX")
 
+# Skylib workspace boilerplate
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+    ],
+    sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+)
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+
 local_repository(
     name = "bazel_ros2_rules",
     path = "../bazel_ros2_rules",

--- a/ros2_example_bazel_installed/WORKSPACE
+++ b/ros2_example_bazel_installed/WORKSPACE
@@ -1,30 +1,37 @@
 workspace(name = "ros2_example_bazel_installed")
 
 load("//tools:environ.bzl", "environment_repository")
+
 environment_repository(
     name = "ros2_example_bazel_installed_environ",
     envvars = ["ROS2_DISTRO_PREFIX"],
 )
+
 load("@ros2_example_bazel_installed_environ//:environ.bzl", "ROS2_DISTRO_PREFIX")
 
 # Skylib workspace boilerplate
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "bazel_skylib",
+    sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
     urls = [
         "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
         "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
     ],
-    sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
 )
+
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
 bazel_skylib_workspace()
 
 local_repository(
     name = "bazel_ros2_rules",
     path = "../bazel_ros2_rules",
 )
+
 load("@bazel_ros2_rules//deps:defs.bzl", "add_bazel_ros2_rules_dependencies")
+
 add_bazel_ros2_rules_dependencies()
 
 load("@bazel_ros2_rules//ros2:defs.bzl", "ros2_archive")
@@ -48,17 +55,17 @@ ROS2_PACKAGES = [
 ros2_archive(
     name = "ros2" if not ROS2_DISTRO_PREFIX else "ros2_ignored",
     include_packages = ROS2_PACKAGES,
+    sha256_url = "https://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci-CHECKSUM",
+    strip_prefix = "ros2-linux",
     # Note: If you want an exact / unchanging version, you will need to mirror the archive
     # according to versions you want.
     # TODO(hidmic,cottsay): Make release-pinned snapshots of this repository once `drake-ros`
     # itself has versions.
     url = "http://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci.tar.bz2",
-    sha256_url = "https://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci-CHECKSUM",
-    strip_prefix = "ros2-linux",
 )
 
 ros2_local_repository(
     name = "ros2" if ROS2_DISTRO_PREFIX else "ros2_ignored",
-    workspaces = [ROS2_DISTRO_PREFIX],
     include_packages = ROS2_PACKAGES,
+    workspaces = [ROS2_DISTRO_PREFIX],
 )

--- a/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
+++ b/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
@@ -145,8 +145,26 @@ ros_py_test(
         "@ros2//resources/rmw_isolation:rmw_isolation_py",
     ],
     data = [
-        ":ros2_example_apps_msgs_ament_index",
         ":simple_talker",
+        "@ros2//:ros2",
+    ],
+)
+
+# This shows how to ensure a Bazel-provided `ros2` CLI can discover custom
+# messages (#118). See note below.
+ros_py_test(
+    name = "custom_message_list_test",
+    main = "test/custom_message_list_test.py",
+    srcs = ["test/custom_message_list_test.py"],
+    deps = [
+        "@bazel_tools//tools/python/runfiles",
+        "@ros2//resources/rmw_isolation:rmw_isolation_py",
+    ],
+    data = [
+        # This is the main key. You must provide the generated ament index as a
+        # Python dependency. Otherwise, attempting to use `ros2 interface ...`
+        # will indicate the message type is invalid.
+        ":ros2_example_apps_msgs_ament_index",
         "@ros2//:ros2",
     ],
 )

--- a/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
+++ b/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
@@ -161,10 +161,10 @@ ros_py_test(
         "@ros2//resources/rmw_isolation:rmw_isolation_py",
     ],
     data = [
-        # This is the main key. You must provide the generated ament index as a
-        # Python dependency. Otherwise, attempting to use `ros2 interface ...`
-        # will indicate the message type is invalid.
-        ":ros2_example_apps_msgs_ament_index",
+        # This is the main key. You must provide the generated definitions as
+        # a dependency. Otherwise, attempting to use `ros2 interface ...` will
+        # indicate the message type is invalid.
+        ":ros2_example_apps_msgs_defs",
         "@ros2//:ros2",
     ],
 )

--- a/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
+++ b/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
@@ -162,8 +162,10 @@ ros_py_test(
     ],
     data = [
         # This is the main key. You must provide the generated definitions as
-        # a dependency. Otherwise, attempting to use `ros2 interface ...` will
-        # indicate the message type is invalid.
+        # a dependency. It can come through data as is done here, or via any
+        # dependency, such as the C++ (*_cc) or Python (*_py) targets.
+        # Otherwise, `ros2 interface ...` will indicate the message type is
+        # invalid.
         ":ros2_example_apps_msgs_defs",
         "@ros2//:ros2",
     ],

--- a/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
+++ b/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
@@ -145,6 +145,7 @@ ros_py_test(
         "@ros2//resources/rmw_isolation:rmw_isolation_py",
     ],
     data = [
+        ":ros2_example_apps_msgs_ament_index",
         ":simple_talker",
         "@ros2//:ros2",
     ],

--- a/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
+++ b/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
@@ -3,7 +3,7 @@
 
 load("@ros2//:ros_cc.bzl", "ros_cc_binary")
 load("@ros2//:ros_cc.bzl", "ros_cc_test")
-load("@ros2//:ros_py.bzl", "ros_py_binary")
+load("@ros2//:ros_py.bzl", "ros_py_binary", "ros_py_test")
 load("@ros2//:rosidl.bzl", "rosidl_interfaces_group")
 load("//tools:cmd_test.bzl", "cmd_test")
 
@@ -119,4 +119,33 @@ cmd_test(
     ],
     data = ["test/oracle_cc.lldb", ":oracle_cc"],
     size = "small",
+)
+
+ros_py_binary(
+    name = "simple_talker",
+    srcs = ["simple_talker.py"],
+    deps = [
+        ":ros2_example_apps_msgs_py",
+        "@ros2//:rclpy_py",
+    ],
+)
+
+# This shows how to ensure a Bazel-provided `ros2` CLI can print out custom
+# messages (#118). See note below.
+ros_py_test(
+    name = "custom_message_echo_test",
+    main = "test/custom_message_echo_test.py",
+    srcs = ["test/custom_message_echo_test.py"],
+    deps = [
+        # This is the main key - you must provide the generated messages as a
+        # Python dependency. Otherwise, attempting to use `ros2 topic ...` will
+        # indicate the message type is invalid.
+        ":ros2_example_apps_msgs_py",
+        "@bazel_tools//tools/python/runfiles",
+        "@ros2//resources/rmw_isolation:rmw_isolation_py",
+    ],
+    data = [
+        ":simple_talker",
+        "@ros2//:ros2",
+    ],
 )

--- a/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
+++ b/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
@@ -21,104 +21,119 @@ rosidl_interfaces_group(
 ros_cc_binary(
     name = "oracle_cc",
     srcs = ["oracle.cc"],
+    rmw_implementation = "rmw_cyclonedds_cpp",
+    tags = ["requires-network"],
     deps = [
         ":ros2_example_apps_msgs_cc",
         "//ros2_example_common:ros2_example_common_msgs_cc",
-        "@ros2//:rclcpp_cc",
         "@ros2//:rclcpp_action_cc",
+        "@ros2//:rclcpp_cc",
     ],
-    rmw_implementation = "rmw_cyclonedds_cpp",
-    tags = ["requires-network"],
 )
 
 ros_cc_binary(
     name = "inquirer_cc",
     srcs = ["inquirer.cc"],
+    rmw_implementation = "rmw_cyclonedds_cpp",
+    tags = ["requires-network"],
     deps = [
         ":ros2_example_apps_msgs_cc",
         "//ros2_example_common:ros2_example_common_msgs_cc",
-        "@ros2//:rclcpp_cc",
         "@ros2//:rclcpp_action_cc",
+        "@ros2//:rclcpp_cc",
     ],
-    rmw_implementation = "rmw_cyclonedds_cpp",
-    tags = ["requires-network"],
 )
 
 ros_py_binary(
     name = "oracle_py",
     srcs = ["oracle.py"],
     main = "oracle.py",
+    rmw_implementation = "rmw_cyclonedds_cpp",
+    tags = ["requires-network"],
     deps = [
         ":ros2_example_apps_msgs_py",
         "//ros2_example_common:ros2_example_common_msgs_py",
         "@ros2//:rclpy_py",
     ],
-    rmw_implementation = "rmw_cyclonedds_cpp",
-    tags = ["requires-network"],
 )
 
 ros_py_binary(
     name = "inquirer_py",
     srcs = ["inquirer.py"],
     main = "inquirer.py",
+    rmw_implementation = "rmw_cyclonedds_cpp",
+    tags = ["requires-network"],
     deps = [
         ":ros2_example_apps_msgs_py",
         "//ros2_example_common:ros2_example_common_msgs_py",
         "@ros2//:rclpy_py",
     ],
-    rmw_implementation = "rmw_cyclonedds_cpp",
-    tags = ["requires-network"],
 )
-
 
 cc_library(
     name = "talker_cc",
     hdrs = ["talker.h"],
     includes = ["."],
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "listener_cc",
     hdrs = ["listener.h"],
     includes = ["."],
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
 )
 
 ros_cc_test(
-  name = "talker_listener_cc_test",
-  deps = [
-    "@ros2//resources/rmw_isolation:rmw_isolation_cc",
-    "@ros2//:rclcpp_cc",
-    "@ros2//:std_msgs_cc",
-    ":talker_cc",
-    ":listener_cc",
-  ],
-  rmw_implementation = "rmw_cyclonedds_cpp",
-  size = "small",
-  srcs = ["test/talker_listener.cc"],
+    name = "talker_listener_cc_test",
+    size = "small",
+    srcs = ["test/talker_listener.cc"],
+    rmw_implementation = "rmw_cyclonedds_cpp",
+    deps = [
+        ":listener_cc",
+        ":talker_cc",
+        "@ros2//:rclcpp_cc",
+        "@ros2//:std_msgs_cc",
+        "@ros2//resources/rmw_isolation:rmw_isolation_cc",
+    ],
 )
 
 cmd_test(
     name = "gdb_oracle_cc_test",
+    size = "small",
     cmd = [
         "gdb",
-        "-x", "$(location :test/oracle_cc.gdb)", "--batch", "--args",
-        "$(location :oracle_cc)", "--ros-args", "--disable-external-lib-logs",
+        "-x",
+        "$(location :test/oracle_cc.gdb)",
+        "--batch",
+        "--args",
+        "$(location :oracle_cc)",
+        "--ros-args",
+        "--disable-external-lib-logs",
     ],
-    data = ["test/oracle_cc.gdb", ":oracle_cc"],
-    size = "small",
+    data = [
+        "test/oracle_cc.gdb",
+        ":oracle_cc",
+    ],
 )
 
 cmd_test(
     name = "lldb_oracle_cc_test",
+    size = "small",
     cmd = [
         "lldb",
-        "-s", "$(location :test/oracle_cc.lldb)", "--batch", "--",
-        "$(location :oracle_cc)", "--ros-args", "--disable-external-lib-logs",
+        "-s",
+        "$(location :test/oracle_cc.lldb)",
+        "--batch",
+        "--",
+        "$(location :oracle_cc)",
+        "--ros-args",
+        "--disable-external-lib-logs",
     ],
-    data = ["test/oracle_cc.lldb", ":oracle_cc"],
-    size = "small",
+    data = [
+        "test/oracle_cc.lldb",
+        ":oracle_cc",
+    ],
 )
 
 ros_py_binary(
@@ -134,8 +149,12 @@ ros_py_binary(
 # messages (#118). See note below.
 ros_py_test(
     name = "custom_message_echo_test",
-    main = "test/custom_message_echo_test.py",
     srcs = ["test/custom_message_echo_test.py"],
+    data = [
+        ":simple_talker",
+        "@ros2",
+    ],
+    main = "test/custom_message_echo_test.py",
     deps = [
         # This is the main key - you must provide the generated messages as a
         # Python dependency. Otherwise, attempting to use `ros2 topic ...` will
@@ -144,22 +163,13 @@ ros_py_test(
         "@bazel_tools//tools/python/runfiles",
         "@ros2//resources/rmw_isolation:rmw_isolation_py",
     ],
-    data = [
-        ":simple_talker",
-        "@ros2//:ros2",
-    ],
 )
 
 # This shows how to ensure a Bazel-provided `ros2` CLI can discover custom
 # messages (#118). See note below.
 ros_py_test(
     name = "custom_message_list_test",
-    main = "test/custom_message_list_test.py",
     srcs = ["test/custom_message_list_test.py"],
-    deps = [
-        "@bazel_tools//tools/python/runfiles",
-        "@ros2//resources/rmw_isolation:rmw_isolation_py",
-    ],
     data = [
         # This is the main key. You must provide the generated definitions as
         # a dependency. It can come through data as is done here, or via any
@@ -167,6 +177,11 @@ ros_py_test(
         # Otherwise, `ros2 interface ...` will indicate the message type is
         # invalid.
         ":ros2_example_apps_msgs_defs",
-        "@ros2//:ros2",
+        "@ros2",
+    ],
+    main = "test/custom_message_list_test.py",
+    deps = [
+        "@bazel_tools//tools/python/runfiles",
+        "@ros2//resources/rmw_isolation:rmw_isolation_py",
     ],
 )

--- a/ros2_example_bazel_installed/ros2_example_apps/simple_talker.py
+++ b/ros2_example_bazel_installed/ros2_example_apps/simple_talker.py
@@ -1,0 +1,26 @@
+import rclpy
+import rclpy.node
+
+from ros2_example_apps_msgs.msg import Status
+
+
+class StatusPublisher(rclpy.node.Node):
+    def __init__(self):
+        super().__init__("test")
+        self._pub = self.create_publisher(Status, "/status", 10)
+        self._timer = self.create_timer(0.1, self._callback)
+
+    def _callback(self):
+        self._pub.publish(Status())
+
+
+def main():
+    rclpy.init()
+    try:
+        rclpy.spin(StatusPublisher())
+    finally:
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_example_bazel_installed/ros2_example_apps/test/custom_message_echo_test.py
+++ b/ros2_example_bazel_installed/ros2_example_apps/test/custom_message_echo_test.py
@@ -22,6 +22,13 @@ def main():
     assert topic_echo.returncode == 0
     talker.kill()
 
+    interfaces = subprocess.run(
+        [ros2_bin, "interface", "list"],
+        check=True, text=True, stdout=subprocess.PIPE,
+    ).stdout
+    print(interfaces)
+    assert "ros2_example_apps_msgs/msg/Status" in interfaces
+
     print("[ Done ]")
 
 

--- a/ros2_example_bazel_installed/ros2_example_apps/test/custom_message_echo_test.py
+++ b/ros2_example_bazel_installed/ros2_example_apps/test/custom_message_echo_test.py
@@ -16,7 +16,9 @@ def main():
         "ros2_example_bazel_installed/ros2_example_apps/simple_talker")
 
     timeout = 5.0
-    topic_echo = subprocess.Popen([ros2_bin, "topic", "echo", "--once", "/status"])
+    topic_echo = subprocess.Popen([
+        ros2_bin, "topic", "echo", "--once",
+        "/status", "ros2_example_apps_msgs/msg/Status"])
     talker = subprocess.Popen([talker_bin])
     topic_echo.wait(timeout=timeout)
     assert topic_echo.returncode == 0

--- a/ros2_example_bazel_installed/ros2_example_apps/test/custom_message_echo_test.py
+++ b/ros2_example_bazel_installed/ros2_example_apps/test/custom_message_echo_test.py
@@ -1,0 +1,29 @@
+import os
+import subprocess
+
+from bazel_tools.tools.python.runfiles import runfiles
+from rmw_isolation import isolate_rmw_by_path
+
+
+def main():
+    if "TEST_TMPDIR" in os.environ:
+        isolate_rmw_by_path(os.environ["TEST_TMPDIR"])
+        os.environ["ROS_HOME"] = os.path.join(os.environ["TEST_TMPDIR"])
+
+    manifest = runfiles.Create()
+    ros2_bin = manifest.Rlocation("ros2/ros2")
+    talker_bin = manifest.Rlocation(
+        "ros2_example_bazel_installed/ros2_example_apps/simple_talker")
+
+    timeout = 5.0
+    topic_echo = subprocess.Popen([ros2_bin, "topic", "echo", "--once", "/status"])
+    talker = subprocess.Popen([talker_bin])
+    topic_echo.wait(timeout=timeout)
+    assert topic_echo.returncode == 0
+    talker.kill()
+
+    print("[ Done ]")
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_example_bazel_installed/ros2_example_apps/test/custom_message_list_test.py
+++ b/ros2_example_bazel_installed/ros2_example_apps/test/custom_message_list_test.py
@@ -12,17 +12,13 @@ def main():
 
     manifest = runfiles.Create()
     ros2_bin = manifest.Rlocation("ros2/ros2")
-    talker_bin = manifest.Rlocation(
-        "ros2_example_bazel_installed/ros2_example_apps/simple_talker")
 
-    timeout = 5.0
-    topic_echo = subprocess.Popen([
-        ros2_bin, "topic", "echo", "--once",
-        "/status", "ros2_example_apps_msgs/msg/Status"])
-    talker = subprocess.Popen([talker_bin])
-    topic_echo.wait(timeout=timeout)
-    assert topic_echo.returncode == 0
-    talker.kill()
+    interfaces = subprocess.run(
+        [ros2_bin, "interface", "list"],
+        check=True, text=True, stdout=subprocess.PIPE,
+    ).stdout
+    print(interfaces)
+    assert "ros2_example_apps_msgs/msg/Status" in interfaces
 
     print("[ Done ]")
 

--- a/ros2_example_bazel_installed/test/shimmed_sentinel.cc
+++ b/ros2_example_bazel_installed/test/shimmed_sentinel.cc
@@ -1,0 +1,13 @@
+#include <cstdlib>
+#include <iostream>
+
+const char * kShimmedSentinel = "_BAZEL_ROS2_RULES_SHIMMED";
+
+int main(int argc, char* argv[]) {
+  bool shimmed = (nullptr != getenv(kShimmedSentinel));
+  bool app_present = (nullptr != getenv("AMENT_PREFIX_PATH"));
+
+  std::cout << "{\"shimmed\": " << shimmed
+    << ", \"AMENT_PREFIX_PATH present\": " << app_present << "}";
+  return 0;
+}

--- a/ros2_example_bazel_installed/test/shimmed_sentinel.py
+++ b/ros2_example_bazel_installed/test/shimmed_sentinel.py
@@ -1,0 +1,12 @@
+import json
+import os
+
+
+assert __name__ == '__main__'
+
+result = {
+    'shimmed': '_BAZEL_ROS2_RULES_SHIMMED' in os.environ,
+    'AMENT_PREFIX_PATH present': 'AMENT_PREFIX_PATH' in os.environ
+}
+
+print(json.dumps(result))

--- a/ros2_example_bazel_installed/test/shimmed_sentinel_test.py
+++ b/ros2_example_bazel_installed/test/shimmed_sentinel_test.py
@@ -1,0 +1,77 @@
+"""
+Test sentinel environment variable handling in dload shims.
+
+These tests check that shimmed executables set environment variables normally,
+but skip modifying environment variables when a sentinel variable is set.
+This is used to avoid modifying environment variables twice when a binary
+wrapped with a dload shim is called in a subprocess of another binary that was
+also wrapped in a dload shim.
+"""
+
+import copy
+import json
+import os
+import subprocess
+import unittest
+
+from bazel_tools.tools.python.runfiles import runfiles
+
+SHIM_SENTINEL = "_BAZEL_ROS2_RULES_SHIMMED"
+
+
+def run_bazel_target(target, env, *args):
+    """Run a bazel executable target and return stdout."""
+    r = runfiles.Create()
+    env = copy.deepcopy(env)
+    # The binaries used by this test need their runfiles to run successfully.
+    # Give them the test's runfiles, because they include the binaries'
+    # runfiles, and are the only ones guaranteed to exist.
+    # See RobotLocomotion/drake-ros#106 for more info.
+    env.update(r.EnvVars())
+    p = subprocess.Popen(
+        [r.Rlocation(target)] + list(args),
+        env=env,
+        stdout=subprocess.PIPE)
+    return p.communicate()[0].decode()
+
+
+class TestShim(unittest.TestCase):
+
+    def setUp(self):
+        assert SHIM_SENTINEL not in os.environ
+
+        self._mock_shimmed_env = {SHIM_SENTINEL: ""}
+
+    def test_shimmed_once_cc(self):
+        stdout = run_bazel_target(
+            "ros2_example_bazel_installed/shimmed_sentinel_cc", {})
+        result = json.loads(stdout)
+        self.assertTrue(result['shimmed'])
+        self.assertTrue(result['AMENT_PREFIX_PATH present'])
+
+    def test_mock_shimmed_twice_cc(self):
+        stdout = run_bazel_target(
+            "ros2_example_bazel_installed/shimmed_sentinel_cc",
+            self._mock_shimmed_env)
+        result = json.loads(stdout)
+        self.assertTrue(result['shimmed'])
+        self.assertFalse(result['AMENT_PREFIX_PATH present'])
+
+    def test_shimmed_once_py(self):
+        stdout = run_bazel_target(
+            "ros2_example_bazel_installed/shimmed_sentinel_py", {})
+        result = json.loads(stdout)
+        self.assertTrue(result['shimmed'])
+        self.assertTrue(result['AMENT_PREFIX_PATH present'])
+
+    def test_mock_shimmed_twice_py(self):
+        stdout = run_bazel_target(
+            "ros2_example_bazel_installed/shimmed_sentinel_py",
+            self._mock_shimmed_env)
+        result = json.loads(stdout)
+        self.assertTrue(result['shimmed'])
+        self.assertFalse(result['AMENT_PREFIX_PATH present'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
@EricCousineau-TRI Mind having a look? I'm struggling to make some runfiles in Bazel.


As part of RobotLocomotion/drake-ros#118 and RobotLocomotion/drake-ros#120 I'm stuck on the first key piece of https://github.com/RobotLocomotion/drake-ros/issues/118#issuecomment-1217184890 .

I'm trying to create symlinks that match the ament resource index layout. I've created a rule `rosidl_generate_ament_index_entry` which creates a manifest of all the interface files. It uses [ctx.runfiles(root_symlinks)](https://bazel.build/rules/lib/ctx#runfiles) to symlink the manifest and interface files into the appropriate locations. This target is `//ros2_example_apps:ros2_example_apps_msgs_ament_index`. I then added that target as a `:data` dependency on `bazel build //ros2_example_apps:custom_message_echo_test`.

Running these commands, I was expecting to see the symlinks as runfiles to the test, but I don't see them. Any idea why?

```console
focal:osrf> bazel clean --expunge
INFO: Starting clean (this may take a while). Consider using --async if the clean takes more than several minutes.
focal:osrf> bazel build //ros2_example_apps:custom_message_echo_test
Starting local Bazel server and connecting to it...
DEBUG: Rule 'ros2' indicated that a canonical reproducible form can be obtained by modifying arguments sha256 = "b7a8982cdc07a090b9719e35ae4735df82f9f648d5b703b93bc9db51e448f81d"
DEBUG: Repository ros2 instantiated at:
  /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/WORKSPACE:35:13: in <toplevel>
Repository rule ros2_archive defined at:
  /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/defs.bzl:307:31: in <toplevel>
DEBUG: /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/rosidl.bzl:184:10: Declaring manifest . ros2_example_apps_msgs
DEBUG: /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/rosidl.bzl:176:10: final args [".", "share/ament_index/resource_index/rosidl_interfaces", "ros2_example_apps_msgs"]
DEBUG: /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/rosidl.bzl:185:10: ./share/ament_index/resource_index/rosidl_interfaces/ros2_example_apps_msgs
DEBUG: /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/rosidl.bzl:176:10: final args [".", "share/ament_index/resource_index/rosidl_interfaces", "ros2_example_apps_msgs"]
DEBUG: /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/rosidl.bzl:176:10: final args [".", "share", "ros2_example_apps_msgs", "msg/Status.idl"]
DEBUG: /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/rosidl.bzl:176:10: final args [".", "share", "ros2_example_apps_msgs", "msg/Status.msg"]
INFO: Analyzed target //ros2_example_apps:custom_message_echo_test (53 packages loaded, 7712 targets configured).
INFO: Found 1 target...
Target //ros2_example_apps:custom_message_echo_test up-to-date:
  bazel-bin/ros2_example_apps/_custom_message_echo_test_shim.py
  bazel-bin/ros2_example_apps/custom_message_echo_test
INFO: Elapsed time: 19.204s, Critical Path: 1.62s
INFO: 400 processes: 363 internal, 37 linux-sandbox.
INFO: Build completed successfully, 400 total actions
focal:osrf> cat bazel-out/k8-opt/bin/ros2_example_apps/custom_message_echo_test.runfiles_manifest | grep Status.idl
ros2/archive/share/action_msgs/msg/GoalStatus.idl /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/archive/share/action_msgs/msg/GoalStatus.idl
ros2_example_bazel_installed/external/ros2/archive/share/action_msgs/msg/GoalStatus.idl /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/archive/share/action_msgs/msg/GoalStatus.idl

# ^^^ No msg/Status.idl in the runfiles manifest? ^^^

focal:osrf> cat bazel-out/k8-opt/bin/ros2_example_apps/custom_message_echo_test.runfiles_manifest | grep ros2_example_apps_msgs
ros2_example_bazel_installed/_solib_k8/_U_S_Sros2_Uexample_Uapps_Cros2_Uexample_Uapps_Umsgs_Uc___Uros2_Uexample_Uapps/libros2_example_apps_msgs__rosidl_typesupport_c.so /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/execroot/ros2_example_bazel_installed/bazel-out/k8-opt/bin/_solib_k8/_U_S_Sros2_Uexample_Uapps_Cros2_Uexample_Uapps_Umsgs_Uc___Uros2_Uexample_Uapps/libros2_example_apps_msgs__rosidl_typesupport_c.so
ros2_example_bazel_installed/_solib_k8/_U_S_Sros2_Uexample_Uapps_Cros2_Uexample_Uapps_Umsgs_Uc___Uros2_Uexample_Uapps/libros2_example_apps_msgs__rosidl_typesupport_introspection_c.so /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/execroot/ros2_example_bazel_installed/bazel-out/k8-opt/bin/_solib_k8/_U_S_Sros2_Uexample_Uapps_Cros2_Uexample_Uapps_Umsgs_Uc___Uros2_Uexample_Uapps/libros2_example_apps_msgs__rosidl_typesupport_introspection_c.so
ros2_example_bazel_installed/ros2_example_apps/libros2_example_apps_msgs__rosidl_typesupport_c.so /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/execroot/ros2_example_bazel_installed/bazel-out/k8-opt/bin/ros2_example_apps/libros2_example_apps_msgs__rosidl_typesupport_c.so
ros2_example_bazel_installed/ros2_example_apps/libros2_example_apps_msgs__rosidl_typesupport_introspection_c.so /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/execroot/ros2_example_bazel_installed/bazel-out/k8-opt/bin/ros2_example_apps/libros2_example_apps_msgs__rosidl_typesupport_introspection_c.so
ros2_example_bazel_installed/ros2_example_apps/ros2_example_apps_msgs/__init__.py 
ros2_example_bazel_installed/ros2_example_apps/ros2_example_apps_msgs/py/__init__.py 
ros2_example_bazel_installed/ros2_example_apps/ros2_example_apps_msgs/py/ros2_example_apps_msgs/__init__.py 
ros2_example_bazel_installed/ros2_example_apps/ros2_example_apps_msgs/py/ros2_example_apps_msgs/msg/__init__.py /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/execroot/ros2_example_bazel_installed/bazel-out/k8-opt/bin/ros2_example_apps/ros2_example_apps_msgs/py/ros2_example_apps_msgs/msg/__init__.py
ros2_example_bazel_installed/ros2_example_apps/ros2_example_apps_msgs/py/ros2_example_apps_msgs/msg/_status.py /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/execroot/ros2_example_bazel_installed/bazel-out/k8-opt/bin/ros2_example_apps/ros2_example_apps_msgs/py/ros2_example_apps_msgs/msg/_status.py
ros2_example_bazel_installed/ros2_example_apps/ros2_example_apps_msgs/py/ros2_example_apps_msgs/ros2_example_apps_msgs_s__rosidl_typesupport_c.cpython-38-x86_64-linux-gnu.so /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/execroot/ros2_example_bazel_installed/bazel-out/k8-opt/bin/ros2_example_apps/ros2_example_apps_msgs/py/ros2_example_apps_msgs/ros2_example_apps_msgs_s__rosidl_typesupport_c.cpython-38-x86_64-linux-gnu.so
ros2_example_bazel_installed/ros2_example_apps/ros2_example_apps_msgs/py/ros2_example_apps_msgs/ros2_example_apps_msgs_s__rosidl_typesupport_introspection_c.cpython-38-x86_64-linux-gnu.so /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/execroot/ros2_example_bazel_installed/bazel-out/k8-opt/bin/ros2_example_apps/ros2_example_apps_msgs/py/ros2_example_apps_msgs/ros2_example_apps_msgs_s__rosidl_typesupport_introspection_c.cpython-38-x86_64-linux-gnu.so


# ^^^ No ros2_example_apps_msgs marker file in the runfiles manifest either? ^^^
```

Before `ctx.runfiles` I also tried `ctx.actions.declare_file` + `ctx.actions.symlink` and had the same result. Any ideas?