### PR TITLE
Update CMake logic for new python rules

### DIFF
--- a/drake_ros/CMakeLists.txt
+++ b/drake_ros/CMakeLists.txt
@@ -20,8 +20,22 @@ add_subdirectory(core)
 add_subdirectory(tf2)
 add_subdirectory(viz)
 
-# Install core python file because ament function can't be used in CMake subdirectory
-ament_python_install_module(core/drake_ros_core.py)
+# Macro not function because ament_python_install_module sets variables used by ament_package()
+macro(install_py_module _relative_name)
+  get_filename_component(_relative_dir "${_relative_name}" DIRECTORY)
+  # Install python files because ament function can't be used in CMake subdirectory
+  ament_python_install_module(${_relative_name}
+    DESTINATION_SUFFIX "drake_ros/${_relative_dir}")
+
+  # Generate same python package in build directory for use in tests
+  file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/py/drake_ros/${_relative_dir}")
+  file(COPY_FILE "${_relative_name}" "${PROJECT_BINARY_DIR}/py/drake_ros/${_relative_name}" ONLY_IF_DIFFERENT)
+endmacro()
+
+install_py_module("./__init__.py")
+install_py_module("core/__init__.py")
+install_py_module("tf2/__init__.py")
+install_py_module("viz/__init__.py")
 
 if(BUILD_TESTING)
     find_package(ament_cmake_clang_format REQUIRED)

--- a/drake_ros/core/CMakeLists.txt
+++ b/drake_ros/core/CMakeLists.txt
@@ -68,12 +68,15 @@ install(
 ###
 # Python bindings
 ###
-pybind11_add_module(drake_ros_core_py SHARED
-  module_py.cc
+pybind11_add_module(py_drake_ros_core SHARED
+  cc_py.cc
 )
-target_link_libraries(drake_ros_core_py PRIVATE drake_ros_core)
-set_target_properties(drake_ros_core_py PROPERTIES OUTPUT_NAME "_drake_ros_core")
-target_include_directories(drake_ros_core_py
+target_link_libraries(py_drake_ros_core PRIVATE drake_ros_core)
+set_target_properties(py_drake_ros_core
+  PROPERTIES
+    OUTPUT_NAME "_cc"
+    LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/py/drake_ros/core/")
+target_include_directories(py_drake_ros_core
   PRIVATE
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>"
 )
@@ -81,8 +84,8 @@ target_include_directories(drake_ros_core_py
 ament_get_python_install_dir(python_install_dir)
 
 install(
-  TARGETS drake_ros_core_py
-  DESTINATION "${python_install_dir}"
+  TARGETS py_drake_ros_core
+  DESTINATION "${python_install_dir}/drake_ros/core/"
 )
 ### End Python bindings
 
@@ -105,7 +108,10 @@ if(BUILD_TESTING)
   )
 
   # TODO(eric, shane): Add environment variable to disable rmw_isolation.
-  ament_add_pytest_test(test_pub_sub_py test/test_pub_sub.py)
+  ament_add_pytest_test(test_pub_sub_py test/test_pub_sub.py
+    # Let Python import mock-install structure in build folder
+    APPEND_ENV
+      "PYTHONPATH=${PROJECT_BINARY_DIR}/py/")
 
   ament_add_gtest(test_drake_ros test/test_drake_ros.cc)
   target_compile_definitions(test_drake_ros

--- a/drake_ros/tf2/CMakeLists.txt
+++ b/drake_ros/tf2/CMakeLists.txt
@@ -55,9 +55,12 @@ install(
 # Python bindings
 ###
 pybind11_add_module(py_drake_ros_tf2 SHARED
-  module_py.cc
+  cc_py.cc
 )
-set_target_properties(py_drake_ros_tf2 PROPERTIES OUTPUT_NAME "drake_ros_tf2")
+set_target_properties(py_drake_ros_tf2
+  PROPERTIES
+    OUTPUT_NAME "_cc"
+    LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/py/drake_ros/tf2/")
 target_link_libraries(py_drake_ros_tf2 PRIVATE drake_ros_tf2)
 
 # Sets PYTHON_INSTALL_DIR
@@ -65,7 +68,7 @@ ament_get_python_install_dir(python_install_dir)
 
 install(
   TARGETS py_drake_ros_tf2
-  DESTINATION "${python_install_dir}"
+  DESTINATION "${python_install_dir}/drake_ros/tf2/"
 )
 ### End Python bindings
 
@@ -88,7 +91,10 @@ if(BUILD_TESTING)
     _TEST_DISABLE_RMW_ISOLATION
   )
 
-  ament_add_pytest_test(test_tf_broadcaster_py test/test_tf_broadcaster.py)
+  ament_add_pytest_test(test_tf_broadcaster_py test/test_tf_broadcaster.py
+    # Let Python import mock-install structure in build folder
+    APPEND_ENV
+      "PYTHONPATH=${PROJECT_BINARY_DIR}/py/")
 
   ament_add_gtest(test_tf2_name_conventions test/test_name_conventions.cc)
   target_include_directories(test_tf2_name_conventions

--- a/drake_ros/viz/CMakeLists.txt
+++ b/drake_ros/viz/CMakeLists.txt
@@ -55,9 +55,12 @@ install(
 # Python bindings
 ###
 pybind11_add_module(py_drake_ros_viz SHARED
-  module_py.cc
+  cc_py.cc
 )
-set_target_properties(py_drake_ros_viz PROPERTIES OUTPUT_NAME "drake_ros_viz")
+set_target_properties(py_drake_ros_viz
+  PROPERTIES
+    OUTPUT_NAME "_cc"
+    LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/py/drake_ros/viz/")
 target_link_libraries(py_drake_ros_viz PRIVATE drake_ros_viz)
 
 # Sets PYTHON_INSTALL_DIR
@@ -65,7 +68,7 @@ ament_get_python_install_dir(python_install_dir)
 
 install(
   TARGETS py_drake_ros_viz
-  DESTINATION "${python_install_dir}"
+  DESTINATION "${python_install_dir}/drake_ros/viz/"
 )
 ### End Python bindings
 
@@ -90,5 +93,8 @@ if(BUILD_TESTING)
     drake_ros_viz
   )
 
-  ament_add_pytest_test(test_python_bindings test/test_python_bindings.py)
+  ament_add_pytest_test(test_python_bindings test/test_python_bindings.py
+    # Let Python import mock-install structure in build folder
+    APPEND_ENV
+      "PYTHONPATH=${PROJECT_BINARY_DIR}/py/")
 endif()


### PR DESCRIPTION
Towards 
https://github.com/RobotLocomotion/drake-ros/pull/238

This updates the CMake logic to work with the new python package structure.

Installing the Python modules is fine. The problem is importing the files from the binary directory at test time. I created a mock-install in the binary directory, which should work, excep there's an import [here](https://github.com/ros2/launch/blob/a9a9bcf071e34b67f18233912b0997cee133fa7a/launch_testing/launch_testing/pytest/hooks.py#L181) that causes `drake_ros` to be imported from the `src` directory of the workspace. The folder names for the package and the placement of the top level `__init__.py` in the `drake_ros` folder look like the Python package. I can't override the import with `PYTHONPATH`, I think because of https://docs.python.org/3/library/sys_path_init.html: `The first entry in the module search path is the directory that contains the input script, if there is one` putting the script path before any `PYTHONPATH` entries.