### PR TITLE
Disable clang-format around drake_ros_py namespace comments

### DIFF
--- a/drake_ros/CMakeLists.txt
+++ b/drake_ros/CMakeLists.txt
@@ -41,9 +41,7 @@ if(BUILD_TESTING)
     find_package(ament_cmake_pycodestyle REQUIRED)
 
     ament_clang_format(CONFIG_FILE .clang-format)
-    # TODO(eric.cousineau): Reenable once both clang-format and cpplint agree
-    # on the same formatting for drake_ros_pybind.h.
-    # ament_cpplint()
+    ament_cpplint()
     ament_pycodestyle(--config pycodestyle.ini)
 endif()
 

--- a/drake_ros/drake_ros/cc_py.cc
+++ b/drake_ros/drake_ros/cc_py.cc
@@ -20,5 +20,7 @@ PYBIND11_MODULE(_cc, m) {
 }
 
 }  // namespace
-}  // namespace DRAKE_ROS_NO_EXPORT
+// clang-format off
+}  // namespace drake_ros_py
+// clang-format on
 }  // namespace drake_ros

--- a/drake_ros/drake_ros/core/cc_pybind.cc
+++ b/drake_ros/drake_ros/core/cc_pybind.cc
@@ -157,6 +157,7 @@ void DefCore(py::module m) {
             std::move(serializer), topic_name, qos, ros_interface);
       }));
 }
-
-}  // namespace DRAKE_ROS_NO_EXPORT
+// clang-format off
+}  // namespace drake_ros_py
+// clang-format on
 }  // namespace drake_ros

--- a/drake_ros/drake_ros/drake_ros_pybind.h
+++ b/drake_ros/drake_ros/drake_ros_pybind.h
@@ -17,6 +17,7 @@ namespace drake_ros_py DRAKE_ROS_NO_EXPORT {
 
 namespace py = pybind11;
 
-// TODO(eric.cousineau): Fix or work around ament clang_format's failures.
-}  // namespace DRAKE_ROS_NO_EXPORT
+// clang-format off
+}  // namespace drake_ros_py
+// clang-format on
 }  // namespace drake_ros

--- a/drake_ros/drake_ros/tf2/cc_pybind.cc
+++ b/drake_ros/drake_ros/tf2/cc_pybind.cc
@@ -58,5 +58,7 @@ void DefTf2(py::module m) {
            py::return_value_policy::reference_internal);
 }
 
-}  // namespace DRAKE_ROS_NO_EXPORT
+// clang-format off
+}  // namespace drake_ros_py
+// clang-format on
 }  // namespace drake_ros

--- a/drake_ros/drake_ros/viz/cc_pybind.cc
+++ b/drake_ros/drake_ros/viz/cc_pybind.cc
@@ -52,5 +52,7 @@ void DefViz(py::module m) {
            py::return_value_policy::reference_internal);
 }
 
-}  // namespace DRAKE_ROS_NO_EXPORT
+// clang-format off
+}  // namespace drake_ros_py
+// clang-format on
 }  // namespace drake_ros


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake-ros/pull/239

Upstream bug filed https://github.com/llvm/llvm-project/issues/61251